### PR TITLE
add reducers

### DIFF
--- a/src/reducers/authedUser.js
+++ b/src/reducers/authedUser.js
@@ -1,0 +1,10 @@
+import { SET_AUTHED_USER } from '../action/authedUser';
+
+export default function authedUser (state=null, action) {
+    switch(action.type){
+        case SET_AUTHED_USER :
+            return action.id
+        default:
+            return state 
+    }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import { users } from './users';
+import { tweets } from './tweets';
+import { authedUser } from './authedUser';
+
+export default combineReducers({
+    users,
+    tweets,
+    authedUser
+})

--- a/src/reducers/tweets.js
+++ b/src/reducers/tweets.js
@@ -1,0 +1,15 @@
+import { RECEIVE_TWEETS } from '../action/tweets';
+
+export default function tweets  (state = {}, action) {
+    switch(action.type){
+        case RECEIVE_TWEETS : 
+            return {
+                // spread operator will generate a new object,
+                // this fulfill the reducer has to be pure function
+                ...state,
+                ...action.tweets 
+            };
+        default : 
+            return state
+    }
+}

--- a/src/reducers/users.js
+++ b/src/reducers/users.js
@@ -1,0 +1,15 @@
+import { RECEIVE_USERS } from '../action/users';
+
+export default function users (state = {}, action) {
+    switch(action.type){
+        case RECEIVE_USERS : 
+            return {
+                // spread operator will generate a new object,
+                // this fulfill the reducer has to be pure function
+                ...state,
+                ...action.users
+            };
+        default : 
+            return state
+    }
+}


### PR DESCRIPTION
**_Done In This PR_**

Added the reducers for users, tweets and authedUser;
At this point, our store looks like this: 
<img width="455" alt="Screen Shot 2020-04-17 at 6 11 29 PM" src="https://user-images.githubusercontent.com/40004335/79618025-ed406b00-80d6-11ea-92a9-9bd5f1b6807b.png">
Also inside the index.js file, combined all the reducers to a root reducer:
```
export default combineReducers({
    users: users,
    tweets: tweets,
    authedUser: authedUser
})
```
this is same with below because the `ES6 property shorthand`
```
export default combineReducers({
    users,
    tweets,
    authedUser
})
```

**_Next_**

Create the store and apply the reducers to the store